### PR TITLE
Add HTTPS requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,6 @@ Take a screenshot directly from GLPI and attach it to a ticket, change or proble
 
 This plugin relies on some WebRTC features that are only available on a few browsers (Some features are still a working draft and not implemented into the W3C standard). It works on Chrome and should work on all other Chromium-based browsers (new Edge, Brave, etc), but doesn't work properly on Firefox.
 
+Additionally, browsers only expose this feature when it is being used over HTTPS (or running over localhost). If your GLPI server doesn't use HTTPS yet, this plugin will not work.
+
 ![Preview](https://raw.githubusercontent.com/cconard96/glpi-screenshot-plugin/master/Screenshot%20Plugin%20Preview.gif)

--- a/setup.php
+++ b/setup.php
@@ -35,38 +35,42 @@ function plugin_init_screenshot()
 function plugin_version_screenshot()
 {
 	return [
-	      'name'         => __('Screenshot', 'screenshot'),
-	      'version'      => PLUGIN_SCREENSHOT_VERSION,
-	      'author'       => 'Curtis Conard',
-	      'license'      => 'GPLv2',
-	      'homepage'     =>'https://github.com/cconard96/glpi-screenshot-plugin',
-	      'requirements' => [
-	         'glpi'   => [
-	            'min' => PLUGIN_SCREENSHOT_MIN_GLPI,
-	            'max' => PLUGIN_SCREENSHOT_MAX_GLPI
-	         ]
-	      ]
-	   ];
+      'name'         => __('Screenshot', 'screenshot'),
+      'version'      => PLUGIN_SCREENSHOT_VERSION,
+      'author'       => 'Curtis Conard',
+      'license'      => 'GPLv2',
+      'homepage'     =>'https://github.com/cconard96/glpi-screenshot-plugin',
+      'requirements' => [
+         'glpi'   => [
+            'min' => PLUGIN_SCREENSHOT_MIN_GLPI,
+            'max' => PLUGIN_SCREENSHOT_MAX_GLPI
+         ]
+      ]
+   ];
 }
 
 function plugin_screenshot_check_prerequisites()
 {
 	if (!method_exists('Plugin', 'checkGlpiVersion')) {
-	      $version = preg_replace('/^((\d+\.?)+).*$/', '$1', GLPI_VERSION);
-	      $matchMinGlpiReq = version_compare($version, PLUGIN_SCREENSHOT_MIN_GLPI, '>=');
-	      $matchMaxGlpiReq = version_compare($version, PLUGIN_SCREENSHOT_MAX_GLPI, '<');
-	      if (!$matchMinGlpiReq || !$matchMaxGlpiReq) {
-	         echo vsprintf(
-	            'This plugin requires GLPI >= %1$s and < %2$s.',
-	            [
-	               PLUGIN_SCREENSHOT_MIN_GLPI,
-	               PLUGIN_SCREENSHOT_MAX_GLPI,
-	            ]
-	         );
-	         return false;
-	      }
-	   }
-	   return true;
+      $version = preg_replace('/^((\d+\.?)+).*$/', '$1', GLPI_VERSION);
+      $matchMinGlpiReq = version_compare($version, PLUGIN_SCREENSHOT_MIN_GLPI, '>=');
+      $matchMaxGlpiReq = version_compare($version, PLUGIN_SCREENSHOT_MAX_GLPI, '<');
+      if (!$matchMinGlpiReq || !$matchMaxGlpiReq) {
+         echo vsprintf(
+            'This plugin requires GLPI >= %1$s and < %2$s.',
+            [
+               PLUGIN_SCREENSHOT_MIN_GLPI,
+               PLUGIN_SCREENSHOT_MAX_GLPI,
+            ]
+         );
+         return false;
+      }
+   }
+   if (empty($_SERVER['HTTPS']) && !in_array($_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1'])) {
+      echo 'This plugin requires GLPI be served over HTTPS';
+      return false;
+   }
+   return true;
 }
 
 function plugin_screenshot_check_config()


### PR DESCRIPTION
Add notice of the requirement (The browsers requirement and not mine) where GLPI must be accessed over HTTPS for this feature to function.
Add prerequisite to block plugin install if not being accessed over HTTPS (or localhost for devs/testing only).