### PR TITLE
Support more desktop browsers

### DIFF
--- a/ajax/screenshot.php
+++ b/ajax/screenshot.php
@@ -44,7 +44,7 @@ if (!isset($_POST['itemtype'], $_POST['items_id'], $_POST['format'])) {
 
 $config = Config::getConfigurationValues('plugin:screenshot');
 if ((isset($_POST['img']) && $_POST['format'] !== $config['screenshot_format']) ||
-   (isset($_FILES['blob']) && $_POST['format'] !== $config['screenrecording_format'])) {
+   (isset($_FILES['blob']) && $_POST['format'] !== 'video/webm')) {
    die(400);
 }
 

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -51,11 +51,7 @@ class PluginScreenshotConfig extends CommonGLPI
       Dropdown::showFromArray('screenshot_format', PluginScreenshotScreenshot::getScreenshotFormats(), [
          'value' => $config['screenshot_format'] ?? 'image/png'
       ]);
-      echo '</td><td>' ._x('config', 'Screen Recording Format', 'jamf'). '</td><td>';
-      Dropdown::showFromArray('screenrecording_format', PluginScreenshotScreenshot::getScreenRecordingFormats(), [
-         'value' => $config['screenrecording_format'] ?? 'video/webm'
-      ]);
-      echo '</td></tr>';
+      echo '</td><td></td><td></td></tr>';
       echo '</table>';
 
       echo "<table class='tab_cadre_fixe'>";

--- a/inc/screenshot.class.php
+++ b/inc/screenshot.class.php
@@ -64,7 +64,7 @@ class PluginScreenshotScreenshot extends CommonGLPI {
    {
       return [
          'video/webm'   => 'WEBm',
-         'video/mp4'    => 'MP4',
+         //'video/mp4'    => 'MP4',
       ];
    }
 
@@ -74,7 +74,7 @@ class PluginScreenshotScreenshot extends CommonGLPI {
          'image/png'    => 'png',
          'image/jpg'    => 'jpg',
          'video/webm'   => 'webm',
-         'video/mp4'    => 'mp4',
+         //'video/mp4'    => 'mp4',
       ];
       return $mappings[$mime] ?? null;
    }

--- a/inc/screenshot.class.php
+++ b/inc/screenshot.class.php
@@ -50,7 +50,6 @@ class PluginScreenshotScreenshot extends CommonGLPI {
             <i class='fas fa-video'></i>" .
             __("Screen Recording") . "</li>";
       }
-      echo Html::scriptBlock('window.GLPIMediaCapture.evalTimelineAction();');
    }
 
    public static function getScreenshotFormats(): array

--- a/inc/screenshot.class.php
+++ b/inc/screenshot.class.php
@@ -50,6 +50,7 @@ class PluginScreenshotScreenshot extends CommonGLPI {
             <i class='fas fa-video'></i>" .
             __("Screen Recording") . "</li>";
       }
+      echo Html::scriptBlock('window.GLPIMediaCapture.evalTimelineAction();');
    }
 
    public static function getScreenshotFormats(): array

--- a/js/screenshot.js
+++ b/js/screenshot.js
@@ -155,6 +155,11 @@ window.GLPIMediaCapture = new function() {
       return ((settings.width * settings.height) * settings.frameRate * motion_factor) / 10;
    }
 
+   function getRecordingCodec(requested_format) {
+      const codecs = ['vp9', 'vp8'];
+      return codecs.find(c => MediaRecorder.isTypeSupported(requested_format + ';codecs=' + c))
+   }
+
    /**
     * Prompt the user to select a screen device, (re)-build the form, and wait for the user to start the MediaRecorder.
     * Then, this will continually grab frames from the video stream at a rate of 10 FPS and update the preview canvas until the user stops the recording.
@@ -170,7 +175,7 @@ window.GLPIMediaCapture = new function() {
          const track = mediaStream.getVideoTracks()[0];
 
          let recorder = new MediaRecorder(mediaStream, {
-            mimeType: config['screenrecording_format'] + ';codecs=vp9',
+            mimeType: getRecordingMimeType('video/webm'),
             videoBitsPerSecond: getPreferredBitrate(track),
          });
          let blob = null;
@@ -194,7 +199,7 @@ window.GLPIMediaCapture = new function() {
             data.append('blob', blob);
             data.append('itemtype', itemtype);
             data.append('items_id', items_id);
-            data.append('format', config['screenrecording_format']);
+            data.append('format', 'video/webm');
             $.ajax({
                type: 'POST',
                url: CFG_GLPI.root_doc+"/"+GLPI_PLUGINS_PATH.screenshot+"/ajax/screenshot.php",
@@ -229,7 +234,7 @@ window.GLPIMediaCapture = new function() {
 
                // Create blob
                blob = new Blob(chunks, {
-                  type: config['screenrecording_format']
+                  type: 'video/webm'
                });
             }
          }

--- a/js/screenshot.js
+++ b/js/screenshot.js
@@ -175,7 +175,7 @@ window.GLPIMediaCapture = new function() {
          const track = mediaStream.getVideoTracks()[0];
 
          let recorder = new MediaRecorder(mediaStream, {
-            mimeType: getRecordingMimeType('video/webm'),
+            mimeType: 'video/webm;codecs='+getRecordingCodec('video/webm'),
             videoBitsPerSecond: getPreferredBitrate(track),
          });
          let blob = null;

--- a/js/screenshot.js
+++ b/js/screenshot.js
@@ -31,6 +31,21 @@ window.GLPIMediaCapture = new function() {
 
    let config = {};
 
+   function isMobileBrowser() {
+      const userAgent = navigator.userAgent.toLowerCase();
+      return userAgent.match(/ipad|iphone|ipod|android/i);
+   }
+
+   /**
+    * Check if the browser supports this feature. If not, this will hide the timeline button.
+    */
+   this.evalTimelineAction = function() {
+      if (isMobileBrowser()) {
+         $('#attach_screenshot_timeline').hide();
+         $('#attach_screenrecording_timeline').hide();
+      }
+   }
+
    /**
     * Update a preview and full-size canvas based on the supplied image.
     * Each canvas parameter is optional and can be skipped by setting it to null.

--- a/js/screenshot.js
+++ b/js/screenshot.js
@@ -213,19 +213,6 @@ window.GLPIMediaCapture = new function() {
 
          $(edit_panel).on('click', 'button[name="stop"]', {}, stopRecording);
          $(edit_panel).on('click', 'button[name="upload"]', {}, upload);
-         imageCapture = new ImageCapture(track);
-
-         const grab_preview_frame = setInterval(function() {
-            if (track.readyState === 'ended') {
-               clearInterval(grab_preview_frame);
-               return;
-            }
-            imageCapture.grabFrame().then(img => {
-               // Depending on how quickly this occurs, some frames may be rendered out of sequence since this isn't blocking.
-               // It probably doesn't matter much as this is just for the preview
-               updateCanvases(img, edit_panel.find('#screenshotPreview').get(0));
-            }).catch(function() {});
-         }, 1000 / 30); // 30 FPS
 
          let chunks = [];
          recorder.ondataavailable = function(event) {
@@ -248,6 +235,7 @@ window.GLPIMediaCapture = new function() {
             $(this).remove();
 
             recorder.start();
+            edit_panel.find('#screenshotPreview').get(0).srcObject = recorder.stream;
          }
          const restartRecording = function() {
             if (recorder !== undefined) {
@@ -264,10 +252,10 @@ window.GLPIMediaCapture = new function() {
 
       $(edit_panel).html(`
          <table class="tab_cadre_fixe">
-            <tr class="headerRow"><th>New Item - Screenshot</th></tr>
+            <tr class="headerRow"><th>New Item - Screen Recording</th></tr>
             <tr>
                 <td>
-                  <canvas id="screenshotPreview" width="${preview_size[0]}" height="${preview_size[1]}"></canvas>
+                  <video id="screenshotPreview" width="${preview_size[0]}" height="${preview_size[1]}" autoplay muted></video>
                 </td>
             </tr>
             <tr>


### PR DESCRIPTION
- [X] Drop ImageCapture requirement for screenshots. The plugin will still use ImageCapture if it is available but if not, it uses a workaround. This should be good enough for our uses and doesn't require a polyfill. This could be back-ported to 1.0.X.
- [x] Drop ImageCapture requirement for screen recordings and try using a workaround like for screenshots. This would be for 1.1.X only.

Browsers Tested
- [x] Chrome 86 (Linux)
- [ ] ~Chrome Android (Latest)~
- [x] Firefox 75 (Linux)
- [ ] ~Firefox Android (Latest)~
- [x] Edge 87 (Chromium based, Windows)