### PR TITLE
Improve HTTPS check

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -22,7 +22,9 @@
 
 function plugin_screenshot_install()
 {
-   if (empty($_SERVER['HTTPS']) && !in_array($_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1'])) {
+   $is_https = !empty($_SERVER['HTTPS']) || (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https');
+   $is_localhost = in_array($_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1']) || (!empty($_SERVER['HTTP_HOST']) && strpos($_SERVER['HTTP_HOST'], 'localhost') !== false);
+   if ($is_https || $is_localhost) {
       echo 'This plugin requires GLPI be served over HTTPS';
       return false;
    }


### PR DESCRIPTION
Improved HTTPS (or secure context) check to better support web servers behind reverse proxies.