### PR TITLE
Do not check auth for config ajax

### DIFF
--- a/ajax/config.php
+++ b/ajax/config.php
@@ -31,8 +31,6 @@ if (!$plugin->isActivated('screenshot')) {
 
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
    // Bad request method
    die(405);


### PR DESCRIPTION
Checking the logged in user on the config AJAX would cause a failure when not logged in. This broke some unauthenticated pages like in Form Creator. Since the config returns only the preferred file formats, there isn't a need for this check.